### PR TITLE
fix:  auth-sample-react-client context definition on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
   auth-sample-react-client:
     image: ${DOCKER_REGISTRY-}auth-sample-react-client
     build:
-      context: .
-      dockerfile: src/Samples.WeatherApi.ReactClient/Dockerfile
+      context: src/Samples.WeatherApi.ReactClient
+      dockerfile: Dockerfile
     networks:
       - overlay
 


### PR DESCRIPTION
fixed:  auth-sample-react-client context definition on docker-compose.yml was causing error: 

> 'failed to solve: failed to compute cache key: failed to calculate checksum of ref "/package.json": not found' 

when running 
`docker compose up`